### PR TITLE
Fix race condition in script loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="stylesheets/styles.css?v=1.1.1">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="scripts/scripts.js" async></script>
+	<script src="scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -9,7 +9,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-  <script src="../scripts/scripts.js" async></script>
+  <script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/contactus.html
+++ b/pages/contactus.html
@@ -9,7 +9,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/employment.html
+++ b/pages/employment.html
@@ -9,7 +9,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/news.html
+++ b/pages/news.html
@@ -9,7 +9,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/passtips.html
+++ b/pages/passtips.html
@@ -9,7 +9,7 @@
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/cs.html
+++ b/pages/routes/cs.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/cs.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/dcl-in.html
+++ b/pages/routes/dcl-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/dcl.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/dcl-out.html
+++ b/pages/routes/dcl-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/dcl.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/dcl.html
+++ b/pages/routes/dcl.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/de-a1.html
+++ b/pages/routes/de-a1.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/de.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/de-b1.html
+++ b/pages/routes/de-b1.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/de.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/de.html
+++ b/pages/routes/de.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="../../stylesheets/de.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ds-in.html
+++ b/pages/routes/ds-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ds.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ds-out.html
+++ b/pages/routes/ds-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ds.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ds.html
+++ b/pages/routes/ds.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="../../stylesheets/ds.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/iu.html
+++ b/pages/routes/iu.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/iu.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/lndcl-in.html
+++ b/pages/routes/lndcl-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/lndcl-out.html
+++ b/pages/routes/lndcl-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/lnws-in.html
+++ b/pages/routes/lnws-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/lnws-out.html
+++ b/pages/routes/lnws-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/lrs.html
+++ b/pages/routes/lrs.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/lrs.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ms-in.html
+++ b/pages/routes/ms-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ms.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ms-out.html
+++ b/pages/routes/ms-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ms.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ms.html
+++ b/pages/routes/ms.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="../../stylesheets/ms.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/oc.html
+++ b/pages/routes/oc.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/oc.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ri.html
+++ b/pages/routes/ri.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ri.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/rrt.html
+++ b/pages/routes/rrt.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/rrt.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/uc.html
+++ b/pages/routes/uc.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/uc.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/udc-in.html
+++ b/pages/routes/udc-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/udc.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/udc-out.html
+++ b/pages/routes/udc-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/udc.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/udc.html
+++ b/pages/routes/udc.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="../../stylesheets/udc.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ws-in.html
+++ b/pages/routes/ws-in.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ws.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ws-out.html
+++ b/pages/routes/ws-out.html
@@ -10,8 +10,8 @@
 	<link rel="stylesheet" href="../../stylesheets/ws.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
-	<script src="../../scripts/rsscripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
+	<script src="../../scripts/rsscripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routes/ws.html
+++ b/pages/routes/ws.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="../../stylesheets/ln.css?v=1.1.1">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/routeschedule.html
+++ b/pages/routeschedule.html
@@ -22,7 +22,7 @@
 	<link rel="stylesheet" href="../stylesheets/de.css?v=1.0.6">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/services.html
+++ b/pages/services.html
@@ -12,7 +12,7 @@
 	<link rel="stylesheet" href="../stylesheets/advertising.css?v=1.0.6">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../scripts/scripts.js" async></script>
+	<script src="../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/services/advertising.html
+++ b/pages/services/advertising.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/services/charter.html
+++ b/pages/services/charter.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
   <link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/services/lift.html
+++ b/pages/services/lift.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
 	<!-- Bootstrap External Stylesheets (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/academic-a.html
+++ b/pages/stops/academic-a.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ackley.html
+++ b/pages/stops/ackley.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/albert.html
+++ b/pages/stops/albert.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/alfred.html
+++ b/pages/stops/alfred.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/arthur.html
+++ b/pages/stops/arthur.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/baker.html
+++ b/pages/stops/baker.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/baldwin-in.html
+++ b/pages/stops/baldwin-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/baldwin-out.html
+++ b/pages/stops/baldwin-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/bandn.html
+++ b/pages/stops/bandn.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/beethovenmain.html
+++ b/pages/stops/beethovenmain.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/beetleroy-dcl.html
+++ b/pages/stops/beetleroy-dcl.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/beetleroy-lrs.html
+++ b/pages/stops/beetleroy-lrs.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/burbank-in.html
+++ b/pages/stops/burbank-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/burbank-out.html
+++ b/pages/stops/burbank-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/burrisrano.html
+++ b/pages/stops/burrisrano.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cec-vp.html
+++ b/pages/stops/cec-vp.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cedar-in.html
+++ b/pages/stops/cedar-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cedar-out.html
+++ b/pages/stops/cedar-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/chenangolewis.html
+++ b/pages/stops/chenangolewis.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/chestnut-in.html
+++ b/pages/stops/chestnut-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/chestnut-out.html
+++ b/pages/stops/chestnut-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/clarke-in.html
+++ b/pages/stops/clarke-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/clarke-out.html
+++ b/pages/stops/clarke-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/clearview.html
+++ b/pages/stops/clearview.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cleveland-in.html
+++ b/pages/stops/cleveland-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cleveland-out.html
+++ b/pages/stops/cleveland-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/columbus-in.html
+++ b/pages/stops/columbus-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/columbus-out.html
+++ b/pages/stops/columbus-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/cook.html
+++ b/pages/stops/cook.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/couperadmin.html
+++ b/pages/stops/couperadmin.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/courthawley-in.html
+++ b/pages/stops/courthawley-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/courthawley-out.html
+++ b/pages/stops/courthawley-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/courtwash.html
+++ b/pages/stops/courtwash.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/crary.html
+++ b/pages/stops/crary.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/crestmont-in.html
+++ b/pages/stops/crestmont-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/crestmont-out.html
+++ b/pages/stops/crestmont-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/decker.html
+++ b/pages/stops/decker.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/dennys-in.html
+++ b/pages/stops/dennys-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/dennys-out.html
+++ b/pages/stops/dennys-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/dickinson.html
+++ b/pages/stops/dickinson.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/eastgym.html
+++ b/pages/stops/eastgym.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/elfred-in.html
+++ b/pages/stops/elfred-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/elfred-out.html
+++ b/pages/stops/elfred-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/engineering.html
+++ b/pages/stops/engineering.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ethel-in.html
+++ b/pages/stops/ethel-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ethel-out.html
+++ b/pages/stops/ethel-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/exchange.html
+++ b/pages/stops/exchange.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/fayettehenry.html
+++ b/pages/stops/fayettehenry.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/first.html
+++ b/pages/stops/first.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/floralmain-in.html
+++ b/pages/stops/floralmain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/floralmain-out.html
+++ b/pages/stops/floralmain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/frontleroy.html
+++ b/pages/stops/frontleroy.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/frontmain-in.html
+++ b/pages/stops/frontmain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/frontmain-out.html
+++ b/pages/stops/frontmain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/frontriv.html
+++ b/pages/stops/frontriv.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/harrison-in.html
+++ b/pages/stops/harrison-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/harrison-out.html
+++ b/pages/stops/harrison-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/hayes-de.html
+++ b/pages/stops/hayes-de.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/hayes.html
+++ b/pages/stops/hayes.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/helen-in.html
+++ b/pages/stops/helen-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/helen-out.html
+++ b/pages/stops/helen-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/henry.html
+++ b/pages/stops/henry.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/highland.html
+++ b/pages/stops/highland.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/hillside.html
+++ b/pages/stops/hillside.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/hinman.html
+++ b/pages/stops/hinman.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/hollybrook.html
+++ b/pages/stops/hollybrook.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/itc.html
+++ b/pages/stops/itc.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/jackson.html
+++ b/pages/stops/jackson.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/jenisonmain.html
+++ b/pages/stops/jenisonmain.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/laurel-in.html
+++ b/pages/stops/laurel-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/laurel-out.html
+++ b/pages/stops/laurel-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/leroybeet.html
+++ b/pages/stops/leroybeet.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/lester-in.html
+++ b/pages/stops/lester-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/lester-out.html
+++ b/pages/stops/lester-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-academic-a.html
+++ b/pages/stops/ln-academic-a.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-ackley.html
+++ b/pages/stops/ln-ackley.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-arthur.html
+++ b/pages/stops/ln-arthur.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-beetleroy.html
+++ b/pages/stops/ln-beetleroy.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-burbank-in.html
+++ b/pages/stops/ln-burbank-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-burbank-out.html
+++ b/pages/stops/ln-burbank-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-cedar-in.html
+++ b/pages/stops/ln-cedar-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-cedar-out.html
+++ b/pages/stops/ln-cedar-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-chestnut-in.html
+++ b/pages/stops/ln-chestnut-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-chestnut-out.html
+++ b/pages/stops/ln-chestnut-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-clarke-in.html
+++ b/pages/stops/ln-clarke-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-clarke-out.html
+++ b/pages/stops/ln-clarke-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-cleveland-in.html
+++ b/pages/stops/ln-cleveland-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-cleveland-out.html
+++ b/pages/stops/ln-cleveland-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-columbus-in.html
+++ b/pages/stops/ln-columbus-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-columbus-out.html
+++ b/pages/stops/ln-columbus-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-cook.html
+++ b/pages/stops/ln-cook.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-courthawley-in.html
+++ b/pages/stops/ln-courthawley-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-crary.html
+++ b/pages/stops/ln-crary.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-crestmont-in.html
+++ b/pages/stops/ln-crestmont-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-crestmont-out.html
+++ b/pages/stops/ln-crestmont-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-elfred-in.html
+++ b/pages/stops/ln-elfred-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-elfred-out.html
+++ b/pages/stops/ln-elfred-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-ethel-in.html
+++ b/pages/stops/ln-ethel-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-ethel-out.html
+++ b/pages/stops/ln-ethel-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-floralmain-in.html
+++ b/pages/stops/ln-floralmain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-floralmain-out.html
+++ b/pages/stops/ln-floralmain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-frontleroy.html
+++ b/pages/stops/ln-frontleroy.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-frontmain-in.html
+++ b/pages/stops/ln-frontmain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-frontmain-out.html
+++ b/pages/stops/ln-frontmain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-frontriv.html
+++ b/pages/stops/ln-frontriv.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-harrison-in.html
+++ b/pages/stops/ln-harrison-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-harrison-out.html
+++ b/pages/stops/ln-harrison-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-helen-in.html
+++ b/pages/stops/ln-helen-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-helen-out.html
+++ b/pages/stops/ln-helen-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-laurel-in.html
+++ b/pages/stops/ln-laurel-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-laurel-out.html
+++ b/pages/stops/ln-laurel-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-leroybeet.html
+++ b/pages/stops/ln-leroybeet.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-margaret-in.html
+++ b/pages/stops/ln-margaret-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-margaret-out.html
+++ b/pages/stops/ln-margaret-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-mather.html
+++ b/pages/stops/ln-mather.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-matthews.html
+++ b/pages/stops/ln-matthews.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-murrayleroy-in.html
+++ b/pages/stops/ln-murrayleroy-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-murrayleroy-out.html
+++ b/pages/stops/ln-murrayleroy-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-murraymain-in.html
+++ b/pages/stops/ln-murraymain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-murraymain-out.html
+++ b/pages/stops/ln-murraymain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-newyork.html
+++ b/pages/stops/ln-newyork.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-rivbeet-in.html
+++ b/pages/stops/ln-rivbeet-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-rivbeet-out.html
+++ b/pages/stops/ln-rivbeet-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-roberts-in.html
+++ b/pages/stops/ln-roberts-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-roberts-out.html
+++ b/pages/stops/ln-roberts-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-schiller-in.html
+++ b/pages/stops/ln-schiller-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-schiller-out.html
+++ b/pages/stops/ln-schiller-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-statehawley.html
+++ b/pages/stops/ln-statehawley.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-stcharles-ws.html
+++ b/pages/stops/ln-stcharles-ws.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-union.html
+++ b/pages/stops/ln-union.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-willow-in.html
+++ b/pages/stops/ln-willow-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/ln-willow-out.html
+++ b/pages/stops/ln-willow-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mainfloral-in.html
+++ b/pages/stops/mainfloral-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mainfloral-out.html
+++ b/pages/stops/mainfloral-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mainjenison.html
+++ b/pages/stops/mainjenison.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/margaret-in.html
+++ b/pages/stops/margaret-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/margaret-out.html
+++ b/pages/stops/margaret-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mather.html
+++ b/pages/stops/mather.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/matthews.html
+++ b/pages/stops/matthews.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mcguire.html
+++ b/pages/stops/mcguire.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/meadows-de.html
+++ b/pages/stops/meadows-de.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/meadows.html
+++ b/pages/stops/meadows.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mohawk.html
+++ b/pages/stops/mohawk.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/mountainview.html
+++ b/pages/stops/mountainview.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/murrayleroy-in.html
+++ b/pages/stops/murrayleroy-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/murrayleroy-out.html
+++ b/pages/stops/murrayleroy-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/murraymain-in.html
+++ b/pages/stops/murraymain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/murraymain-out.html
+++ b/pages/stops/murraymain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/newing.html
+++ b/pages/stops/newing.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/newyork.html
+++ b/pages/stops/newyork.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/nursing-in.html
+++ b/pages/stops/nursing-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/nursing-out.html
+++ b/pages/stops/nursing-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/oakdale.html
+++ b/pages/stops/oakdale.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/oakeaton.html
+++ b/pages/stops/oakeaton.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/oakmain.html
+++ b/pages/stops/oakmain.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/parkdiner.html
+++ b/pages/stops/parkdiner.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/pharmacy-in.html
+++ b/pages/stops/pharmacy-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/pharmacy-out.html
+++ b/pages/stops/pharmacy-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/physical-in.html
+++ b/pages/stops/physical-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/physical-out.html
+++ b/pages/stops/physical-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/rafuse.html
+++ b/pages/stops/rafuse.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/rivbeet-in.html
+++ b/pages/stops/rivbeet-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/rivbeet-out.html
+++ b/pages/stops/rivbeet-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/roberts-in.html
+++ b/pages/stops/roberts-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/roberts-out.html
+++ b/pages/stops/roberts-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/rr-stop1.html
+++ b/pages/stops/rr-stop1.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/rr-stop2.html
+++ b/pages/stops/rr-stop2.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/schiller-in.html
+++ b/pages/stops/schiller-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/schiller-out.html
+++ b/pages/stops/schiller-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/schubert.html
+++ b/pages/stops/schubert.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/seminary.html
+++ b/pages/stops/seminary.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/stcharlesfloral.html
+++ b/pages/stops/stcharlesfloral.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/stcharlesmain-in.html
+++ b/pages/stops/stcharlesmain-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/stcharlesmain-out.html
+++ b/pages/stops/stcharlesmain-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/stops-template.html
+++ b/pages/stops/stops-template.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/stuyvesant.html
+++ b/pages/stops/stuyvesant.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/susquehanna.html
+++ b/pages/stops/susquehanna.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/swashington.html
+++ b/pages/stops/swashington.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/target.html
+++ b/pages/stops/target.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/telegraph.html
+++ b/pages/stops/telegraph.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/tompkinsconklin.html
+++ b/pages/stops/tompkinsconklin.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/tremont.html
+++ b/pages/stops/tremont.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/uclub-shelter.html
+++ b/pages/stops/uclub-shelter.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/uclub-tower.html
+++ b/pages/stops/uclub-tower.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/udc-far.html
+++ b/pages/stops/udc-far.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/udc-near.html
+++ b/pages/stops/udc-near.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/union.html
+++ b/pages/stops/union.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/walmart.html
+++ b/pages/stops/walmart.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/washlehigh.html
+++ b/pages/stops/washlehigh.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/webster.html
+++ b/pages/stops/webster.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/wegmans.html
+++ b/pages/stops/wegmans.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
 	<!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/westgym.html
+++ b/pages/stops/westgym.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/willowfloral-in.html
+++ b/pages/stops/willowfloral-in.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/willowfloral-out.html
+++ b/pages/stops/willowfloral-out.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 

--- a/pages/stops/willowmain.html
+++ b/pages/stops/willowmain.html
@@ -23,7 +23,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"	/>
   <!-- External Google Font (Do Not Edit!)-->
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Inter">
-	<script src="../../scripts/scripts.js" async></script>
+	<script src="../../scripts/scripts.js" defer></script>
 	<link rel="icon" href="https://occtransport.s3.amazonaws.com/Logos/OCCT+Round+Logo.png">
 </head>
 


### PR DESCRIPTION
I noticed that this site's JS has a race condition that will cause event handlers to sometimes not work.

Sometimes, the event handlers will successfully be registered:
![image](https://github.com/OCCTransport/occtransport.github.io/assets/13039555/328666af-3342-49e4-979d-f5aead434a12)

Other times, they won't be, which causes the Weekday/Weekend toggle to not work:

![image](https://github.com/OCCTransport/occtransport.github.io/assets/13039555/4b0ede48-723b-4880-9f84-319cadbd4c6c)

This is because the `<script>` is setup to load as `async`. This means that the JS will be parsed in parallel with the HTML being parsed, and then the JS will execute as soon as is it's ready - even if the DOM content isn't loaded yet. This means that sometimes the JS will try to register event handlers on elements that don't yet exist.

`defer` maintains the desirable property of parsing JS in parallel with HTML, but defers script execution until the page is leaded.